### PR TITLE
READMEのアップデート

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Amazon, Spotify, Uber など世界的なプロダクトのマネージャーが�
 
 * [プロダクトへの生成系 AI 活用方法をアイディエーションする会](https://speakerdeck.com/icoxfog417/purodakutohenosheng-cheng-xi-ai-huo-yong-fang-fa-wo-aideiesiyonsuruhui) ( 所要時間 1 時間半 ~ 2 時間 )
    * プロダクトで生成系 AI を活用するためのアイデアを発想、検証するためのワークショップです。1) 生成系 AI 活用のポイント、 2) アイディエーション、 3) ビジネスモデルキャンバスを利用したアイデアの効果検証、の 3 パートから成ります。
-* [サービスの解約率を改善シナリオ](./notebooks/scenario_churn/) ( 所要時間 2~3 時間 )
+* [サービスの解約率改善シナリオ](./notebooks/scenario_churn/) ( 所要時間 2~3 時間 )
    * 携帯電話会社での解約率改善を題材に、ビジネス理解からモデルのテストまで一気通貫で体験できるハンズオン。
 
 ## ⚡ ハンズオン資料

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 プロダクトマネージャーが、機械学習の「勝ちパターン」を実現するチームとロードマップが作れるワークショップです。
 
-## :books: Contents
+## :books: ワークショップ資料
 
 ワークショップは3部構成となっています。Titleのリンクから資料へ、Workから成果物用のテンプレートにアクセスできます。
 
@@ -23,29 +23,35 @@ ML Enablement Workshopを利用いただくメリットは3つです。
 * :octocat: **無料**
    * GitHubでOSSとして教材を公開しており、ライセンスの範囲で自由に利用頂くことができます。[ワークショップを開催するためのガイド](https://github.com/aws-samples/aws-ml-enablement-workshop#%E9%96%8B%E5%82%AC%E8%80%85%E5%90%91%E3%81%91%E3%82%AC%E3%82%A4%E3%83%89)も提供し、社内でのデータ活用推進などに活かしていただきます。
 
-関連記事
+## 🔍 関連資料
 
+* [ゲーム業界における生成系AIの活用](https://speakerdeck.com/icoxfog417/gemuye-jie-niokerusheng-cheng-xi-ainohuo-yong)
+   * ゲーム業界で生成系 AI を活用している事例と、活用のためのポイントをまとめた発表した記事です。
+* [プロダクトの成長をリードする生成系 AI の活用戦略](https://speakerdeck.com/icoxfog417/purodakutonocheng-chang-woridosurusheng-cheng-xi-ai-nohuo-yong-zhan-lue)
+   * 短期的な生成系 AI のお試しから、長期的なプロダクトの差別化につなげる戦略の立て方を解説した資料です。Biz 、Dev 、 ML の 3 ステップについて、 生成系 AI の活用事例をベースにポイントを解説しています。
 * [機械学習プロジェクトの約80%が失敗するのは伊達ではないと実感したが、現実に負けないワークショップに挑戦する](https://note.com/piqcy/n/n9c9e97896596)
-   * 改善版公開時の記事
+   * ML Enablement Workshop 改善版について、改善前の課題と改善後のポイントをまとめた記事です。
 * [日本のAI導入効果がアメリカの7分の1程度しかないのはなぜなのか](https://note.com/piqcy/n/na971fee54568)
    * AI白書2022を元にした調査記事
 * [機械学習モデル開発プロジェクトの体験ハンズオンを公開しました](https://note.com/piqcy/n/n51ffb8e02293)
    * 初版公開時の記事
 
-スペシャルコンテンツ
+#### 📌 スペシャルコンテンツ
 
 Amazon, Spotify, Uber など世界的なプロダクトのマネージャーがどのように機械学習を活用しているか Q&A 形式でまとめた記事。
 
 * [データサイエンスを活用するプロダクトマネージャーを訪ねて](docs/journal/README.md)
 
+## :rocket: 短期集中型ワークショップ
 
-## :rocket: ML Enablement Camp
+特定目的にフォーカスし ML Enablement Workshop 本体より短時間で学びを得るワークショップ / ハンズオンのコンテンツです。
 
-AWSのサービスやソリューションを活用し、数日での本番導入を目指すCampコンテンツを提供します。
+* [プロダクトへの生成系 AI 活用方法をアイディエーションする会](https://speakerdeck.com/icoxfog417/purodakutohenosheng-cheng-xi-ai-huo-yong-fang-fa-wo-aideiesiyonsuruhui) ( 所要時間 1 時間半 ~ 2 時間 )
+   * プロダクトで生成系 AI を活用するためのアイデアを発想、検証するためのワークショップです。1) 生成系 AI 活用のポイント、 2) アイディエーション、 3) ビジネスモデルキャンバスを利用したアイデアの効果検証、の 3 パートから成ります。
+* [サービスの解約率を改善シナリオ](./notebooks/scenario_churn/) ( 所要時間 2~3 時間 )
+   * 携帯電話会社での解約率改善を題材に、ビジネス理解からモデルのテストまで一気通貫で体験できるハンズオン。
 
-* Amazon Personalize Prototyping Camp: プロダクトに推薦機能を実装するプログラム。(コンテンツ準備中)
-
-## ⚡ ML Enablement Handson
+## ⚡ ハンズオン資料
 
 開発者向けの機械学習ハンズオン資料です。
 目次のNo.1から順に進めていくことで各開発プロセスでなにを行うのか、なぜ行うのか、どう行うのかを学ぶことができます。ハンズオンは Amazon SageMaker Studio Lab を使用し進めます。アカウントの作成方法や使い方は[Amazon SageMaker Studio Lab の使い方](https://github.com/aws-sagemaker-jp/awesome-studio-lab-jp/blob/main/README_usage.md)を参照してください。
@@ -61,13 +67,6 @@ AWSのサービスやソリューションを活用し、数日での本番導�
 |7    |Train|機械学習モデルを学習する|[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/aws-samples/aws-ml-enablement-handson/blob/main/notebooks/05_train.ipynb)|[![YouTube](https://img.shields.io/badge/YouTube-%23FF0000.svg?style=for-the-badge&logo=YouTube&logoColor=white)](https://youtu.be/-SzZJmZWmOs)|
 |8    |Test|機械学習モデルを評価する|[![Open in SageMaker Studio Lab](https://studiolab.sagemaker.aws/studiolab.svg)](https://studiolab.sagemaker.aws/import/github/aws-samples/aws-ml-enablement-handson/blob/main/notebooks/06_test.ipynb)|(Comming Soon)|
 |9    |Ending|機械学習モデルの開発から運用へ|[![Markdown](https://img.shields.io/badge/markdown-%23000000.svg?style=for-the-badge&logo=markdown&logoColor=white)](docs/ending.md)|(Comming Soon)|
-
-### ビジネス課題別シナリオ
-
-実践的なビジネス課題を題材に機械学習モデル開発プロジェクトの進め方を体験できます。
-
-* [サービスの解約率改善シナリオ](notebooks/scenario_churn)
-
 
 ## 活用事例
 
@@ -91,7 +90,7 @@ ML Enablement Workshopの教材を利用して、社内でワークショップ�
 * [ライセンス](LICENSE)に従い、著作権者であるAWSを明記を頂くと共に著作権法に定める引用の要件を満たすようご利用ください。
 * AWS以外の個人や法人が「ML Enablement Workshop」の名称もしくは同一とみなされる名称でワークショップを開催することを禁止します。お客様の混乱を防ぐための措置で、ご理解をお願い致します。
 
-## Contribution
+## 改善要望
 
 ハンズオンコンテンツについてのご要望や質問を歓迎します！事前に [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications)に目を通して頂ければ幸いです。
 
@@ -101,6 +100,6 @@ ML Enablement Workshopの教材を利用して、社内でワークショップ�
 * セキュリティに関するご連絡: [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications)
 
 
-## LICENSE
+## ライセンス
 
 [MIT-0 License](LICENSE)


### PR DESCRIPTION
[ML Enablement Workshop](https://github.com/aws-samples/aws-ml-enablement-workshop) のコンテンツを追加 / 更新します。

## コンテンツ

* コンテンツのタイトル
   * README.md
* 更新内容
   1. 各セクションのタイトルをわかりやすいよう日本語に修正
   2. 資料未掲載の「ML Enablement Camp」を削除。代わりに、「短期集中型ワークショップ」として「[サービスの解約率改善シナリオ](https://file+.vscode-resource.vscode-cdn.net/c:/Users/ttaakkaa/Documents/locals/codes/aws-ml-enablement-handson/notebooks/scenario_churn)」を配置。ワークショップ全体はより「短期」のメリットがわかるタイトルに変更。
   3. [プロダクトへの生成系 AI 活用方法をアイディエーションする会](https://speakerdeck.com/icoxfog417/purodakutohenosheng-cheng-xi-ai-huo-yong-fang-fa-wo-aideiesiyonsuruhui) を短期集中型ワークショップとして追加。

### Issue 番号

なし

## チェックリスト

* [X] : README.md の表記も更新済み。
* [X] : コンテンツ内に個別顧客に対する機微な情報が含まれないことを確認済み。
* [X] : Notebook の場合、全てのセルが正常に実行終了することを確認済み。 ※今回 Notebook なし
